### PR TITLE
Added dynamic_reconfigure to find package to fix build issue

### DIFF
--- a/bluerov_apps/CMakeLists.txt
+++ b/bluerov_apps/CMakeLists.txt
@@ -4,11 +4,9 @@ project(bluerov_apps)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
+find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure
   geometry_msgs
   nav_msgs
-  pcl_conversions
-  pcl_ros
   roscpp
   rospy
   std_msgs


### PR DESCRIPTION
added dynamic_reconfigure to find package to fix build issue

The dynamic reconfigure required component was not in the find package line of the cmake, causing a build failure when

generate_dynamic_reconfigure_options(
cfg/teleop_joy.cfg
)

was read.
